### PR TITLE
Added new exception for exiting with Escape for excallidraw textboxes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -60,6 +60,12 @@ export default class ZenMode extends Plugin {
 							return;
 						}
 					}
+
+					// Don't exit compact mode with escape in an excalidraw textboxes as they use the escape hotkey to leave out of itself.
+					// The resulting behaviour is very confusing. (Textbox is still focus but the zenmode disables)
+					if (target.className.contains("excalidraw") && target instanceof HTMLTextAreaElement) {
+						return;
+					}
 				}
 				// Only exit if no modal is open (to avoid interfering with Obsidian modals)
 				const activeModal = document.querySelector(".modal");


### PR DESCRIPTION
Exiting out of excalidraw textboxes always made the zen mode disable and me not get out of the text box. This behavior is really annoying since I really enjoy using zen mode for working on stuff since it just lets me focus a bit better and I also really like excalidraw.
Thanks in advance!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where pressing Escape while editing text in Zen mode would unexpectedly exit Zen mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->